### PR TITLE
Update entrypoint.sh to support empty command

### DIFF
--- a/v3.1/alpine/entrypoint.sh
+++ b/v3.1/alpine/entrypoint.sh
@@ -11,6 +11,9 @@ fi
 if traefik "$1" --help >/dev/null 2>&1
 then
     set -- traefik "$@"
+elif test -z "$1"
+then
+    set -- traefik
 else
     echo "= '$1' is not a Traefik command: assuming shell execution." 1>&2
 fi


### PR DESCRIPTION
In case the docker runs without any special command given, we would like to execute traefik without parameters, instead of current implementation that assumes shell execution, and tries to execute an empty string. This allows for running a docker container with configuration in a configuration file, which does not require any special command line arguments passed to the entrypoint.